### PR TITLE
Changes version of bootstrap-table from 1.17.1 -> 1.16.0

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -91,7 +91,7 @@
 <script src="https://unpkg.com/popper.js@1.16.0/dist/umd/popper.js"></script>
 <script src="https://unpkg.com/bootstrap-table@1.17.1/dist/bootstrap-table.min.js"></script>
 <script src="https://unpkg.com/bootstrap-table@1.17.1/dist/extensions/filter-control/bootstrap-table-filter-control.min.js"></script>
-<script src="https://unpkg.com/bootstrap-table@1.15.5/dist/extensions/cookie/bootstrap-table-cookie.min.js"></script>
+<script src="https://unpkg.com/bootstrap-table@1.17.1/dist/extensions/cookie/bootstrap-table-cookie.min.js"></script>
 <script src="https://unpkg.com/tableexport.jquery.plugin/tableExport.min.js"></script>
 <script src="https://unpkg.com/bootstrap-table@1.17.1/dist/extensions/export/bootstrap-table-export.js"></script>
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -16,7 +16,7 @@
     <link rel="stylesheet"
           href="https://unpkg.com/bootstrap-material-design@4.1.1/dist/css/bootstrap-material-design.min.css"
           integrity="sha384-wXznGJNEXNG1NFsbm0ugrLFMQPWswR3lds2VeinahP8N0zJw9VWSopbjv2x7WCvX" crossorigin="anonymous">
-    <link rel="stylesheet" href="https://unpkg.com/bootstrap-table@1.17.1/dist/bootstrap-table.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/bootstrap-table@1.16.0/dist/bootstrap-table.min.css">
 
     <link href="https://use.fontawesome.com/releases/v5.6.3/css/all.css" rel="stylesheet">
 
@@ -89,11 +89,11 @@
         integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
         crossorigin="anonymous"></script>
 <script src="https://unpkg.com/popper.js@1.16.0/dist/umd/popper.js"></script>
-<script src="https://unpkg.com/bootstrap-table@1.17.1/dist/bootstrap-table.min.js"></script>
-<script src="https://unpkg.com/bootstrap-table@1.17.1/dist/extensions/filter-control/bootstrap-table-filter-control.min.js"></script>
-<script src="https://unpkg.com/bootstrap-table@1.17.1/dist/extensions/cookie/bootstrap-table-cookie.min.js"></script>
+<script src="https://unpkg.com/bootstrap-table@1.16.0/dist/bootstrap-table.min.js"></script>
+<script src="https://unpkg.com/bootstrap-table@1.16.0/dist/extensions/filter-control/bootstrap-table-filter-control.min.js"></script>
+<script src="https://unpkg.com/bootstrap-table@1.16.0/dist/extensions/cookie/bootstrap-table-cookie.min.js"></script>
 <script src="https://unpkg.com/tableexport.jquery.plugin/tableExport.min.js"></script>
-<script src="https://unpkg.com/bootstrap-table@1.17.1/dist/extensions/export/bootstrap-table-export.js"></script>
+<script src="https://unpkg.com/bootstrap-table@1.16.0/dist/extensions/export/bootstrap-table-export.js"></script>
 
 
 

--- a/app/templates/dealers.html
+++ b/app/templates/dealers.html
@@ -15,7 +15,7 @@
                 <tr>
                     <th data-field="dealer_code" data-filter-control="select" data-formatter="formatDealer">Code</th>
                     <th data-field="address" data-filter-control="input" data-sortable="true">Address</th>
-                    <th data-field="zip" data-filter-control="input" data-sortable="true" >Zip</th>
+                    <th data-field="zip" data-filter-control="input" data-sortable="true">Zip</th>
                     <th data-field="car_count" data-sortable="true">Total Cars</th>
                 </tr>
                 </thead>


### PR DESCRIPTION
Oddly, the latest version of 1.18.0 (released over the weekend) re-introduces the bug where you're unable to clear the filters. 1.17.1 causes the dealers table to nearly lockup as we've seen. 1.16.0 seems to be fine, and 1.15.1 again is unable to clear filters. 1.16.0 it is!