### PR TITLE
removing scraper from one page

### DIFF
--- a/app/templates/cars-all.html
+++ b/app/templates/cars-all.html
@@ -38,9 +38,6 @@
             </table>
         </div>
     </div>
-    <div>
-        {{ scraper_stats.count }} VINS added in the last 24 hours.
-    </div>
    <br>
     <hr class="icon">
     <br>


### PR DESCRIPTION
Variable isn't available on this page.  Not sure why, but something to do with it loading in the modal in the base.  Can't run the site to debug so this is a quick fix.

Repro -> Click All Cars